### PR TITLE
Show work experience details #187

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ const config = {
       from: 'September 2021',
       to: 'Present',
       companyLink: 'https://example.com',
+      list: ['task 1', 'responsibility 2'],
     },
     {
       company: 'Company Name',
@@ -466,6 +467,7 @@ module.exports = {
       from: 'September 2021',
       to: 'Present',
       companyLink: 'https://example.com',
+      list: ['task 1', 'responsibility 2'],
     },
     {
       company: 'Company Name',

--- a/gitprofile.config.js
+++ b/gitprofile.config.js
@@ -49,6 +49,7 @@ const config = {
       from: 'September 2021',
       to: 'Present',
       companyLink: 'https://example.com',
+      list: ['responsibility 1', 'task 2', 'important project 3'],
     },
     {
       company: 'Company Name',

--- a/src/components/experience/index.jsx
+++ b/src/components/experience/index.jsx
@@ -2,7 +2,7 @@ import { skeleton } from '../../helpers/utils';
 import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-const ListItem = ({ time, position, company, companyLink }) => (
+const ListItem = ({ time, position, company, companyLink, tasks }) => (
   <li className="mb-5 ml-4">
     <div
       className="absolute w-2 h-2 bg-base-300 rounded-full border border-base-300 mt-1.5"
@@ -15,6 +15,15 @@ const ListItem = ({ time, position, company, companyLink }) => (
         {company}
       </a>
     </div>
+    {tasks?.length > 0 && (
+      <div className="text-sm">
+        <ul>
+          {tasks.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
+        </ul>
+      </div>
+    )}
   </li>
 );
 
@@ -72,6 +81,7 @@ const Experience = ({ experiences, loading }) => {
                         companyLink={
                           experience.companyLink ? experience.companyLink : null
                         }
+                        tasks={experience.list}
                       />
                     ))}
                   </Fragment>
@@ -90,6 +100,7 @@ ListItem.propTypes = {
   position: PropTypes.node,
   company: PropTypes.node,
   companyLink: PropTypes.string,
+  tasks: PropTypes.array,
 };
 
 Experience.propTypes = {


### PR DESCRIPTION
Allow users to specify a list with work experience details, e.g. tasks or responsibilities.

![image](https://user-images.githubusercontent.com/2149217/198112391-e51fb637-cbe3-4654-a36c-c40de9b30186.png)

Closes #187 