### PR TITLE
Allow CRLF when linting #198

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "bracketSpacing": true,
   "printWidth": 80,
   "singleQuote": true,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
We should still detect mixed/inconsistent CRLF when linting in the CI at GitHub. Perhaps we can read an environment variable to enable/disable this feature for local linting and CI linting.