### PR TITLE
Update Deploy Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v1.2.3


### PR DESCRIPTION
The old version has a warning and won't deploy
`Warning: Input 'emit_telemetry' has been deprecated with message: Use of this input causes the action to do nothing. You should remove this build step from your workflow.`