### PR TITLE
add custom avatar in config

### DIFF
--- a/gitprofile.config.js
+++ b/gitprofile.config.js
@@ -10,6 +10,9 @@ const config = {
       projects: [], // These projects will not be displayed. example: ['my-project1', 'my-project2']
     },
   },
+  avatar: {
+    url: '', //Set an URL to display an image instead of your GitHub avatar. If left empty, your GitHub avatar will be displayed.
+  },
   social: {
     linkedin: 'ariful-alam',
     twitter: 'arif_szn',

--- a/src/components/GitProfile.jsx
+++ b/src/components/GitProfile.jsx
@@ -60,7 +60,7 @@ const GitProfile = ({ config }) => {
         let data = response.data;
 
         let profileData = {
-          avatar: data.avatar_url,
+          avatar: sanitizedConfig.avatar.url || data.avatar_url,
           name: data.name ? data.name : '',
           bio: data.bio ? data.bio : '',
           location: data.location ? data.location : '',

--- a/src/helpers/utils.jsx
+++ b/src/helpers/utils.jsx
@@ -144,6 +144,9 @@ export const sanitizeConfig = (config) => {
         projects: config?.github?.exclude?.projects || [],
       },
     },
+    avatar: {
+      url: config?.avatar?.url || '',
+    },
     social: {
       linkedin: config?.social?.linkedin,
       twitter: config?.social?.twitter,


### PR DESCRIPTION
Add the possibility to specify a custom avatar in the configuration. If the field is left empty, the Github avatar is displayed