### PR TITLE
Add Discord as social link

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ const config = {
     stackoverflow: '', // format: userid/username
     website: '',
     skype: '',
+    discord: '',
     telegram: '',
     phone: '',
     email: '',
@@ -458,7 +459,7 @@ Your avatar and bio will be fetched from GitHub automatically.
 
 ### Social Links
 
-You can link your social media services you're using, including LinkedIn, Twitter, Mastodon, Facebook, Instagram, YouTube, Dribbble, Behance, Medium, dev, Stack Overflow, Skype, Telegram, personal website, phone and email.
+You can link your social media services you're using, including LinkedIn, Twitter, Mastodon, Facebook, Instagram, YouTube, Dribbble, Behance, Medium, dev, Stack Overflow, Skype, Discord, Telegram, personal website, phone and email.
 
 ```js
 // gitprofile.config.js
@@ -477,6 +478,7 @@ const config = {
     dev: '',
     stackoverflow: '',
     skype: '',
+    discord: '',
     telegram: '',
     website: '',
     phone: '',

--- a/gitprofile.config.js
+++ b/gitprofile.config.js
@@ -23,7 +23,7 @@ const config = {
     dev: 'arifszn',
     stackoverflow: '', // example: '1/jeff-atwood'
     skype: '',
-    discord:'', // Put the invite code. example: `2345678` from https://discord.gg/invite/12345678
+    discord:'', // Put the invite code. example: `12345678` from https://discord.gg/invite/12345678
     telegram: '',
     website: 'https://arifszn.com',
     phone: '',

--- a/gitprofile.config.js
+++ b/gitprofile.config.js
@@ -23,7 +23,7 @@ const config = {
     dev: 'arifszn',
     stackoverflow: '', // example: '1/jeff-atwood'
     skype: '',
-    discord:'', // Put the invite code. example: `12345678` from https://discord.gg/invite/12345678
+    discord: '', // Put the invite code. example: `12345678` from https://discord.gg/invite/12345678
     telegram: '',
     website: 'https://arifszn.com',
     phone: '',

--- a/gitprofile.config.js
+++ b/gitprofile.config.js
@@ -23,6 +23,7 @@ const config = {
     dev: 'arifszn',
     stackoverflow: '', // example: '1/jeff-atwood'
     skype: '',
+    discord:'', // Put the invite code. example: `2345678` from https://discord.gg/invite/12345678
     telegram: '',
     website: 'https://arifszn.com',
     phone: '',

--- a/src/components/GitProfile.jsx
+++ b/src/components/GitProfile.jsx
@@ -257,6 +257,7 @@ GitProfile.propTypes = {
       stackoverflow: PropTypes.string,
       website: PropTypes.string,
       skype: PropTypes.string,
+      discord: PropTypes.string,
       telegram: PropTypes.string,
       phone: PropTypes.string,
       email: PropTypes.string,

--- a/src/components/details/index.jsx
+++ b/src/components/details/index.jsx
@@ -15,6 +15,7 @@ import {
   FaFacebook,
   FaGlobe,
   FaSkype,
+  FaDiscord,
   FaMastodon,
   FaStackOverflow,
   FaTelegram,
@@ -220,6 +221,14 @@ const Details = ({ profile, loading, social, github }) => {
                   title="Skype"
                   value={social.skype}
                   link={`skype:${social.skype}?chat`}
+                />
+              )}
+              {social?.discord && (
+                <ListItem
+                  icon={<FaDiscord />}
+                  title="Discord:"
+                  value={social.discord}
+                  link={`https://discord.gg/${social.discord}`}
                 />
               )}
               {social?.telegram && (

--- a/src/helpers/utils.jsx
+++ b/src/helpers/utils.jsx
@@ -160,6 +160,7 @@ export const sanitizeConfig = (config) => {
       phone: config?.social?.phone,
       email: config?.social?.email,
       skype: config?.social?.skype,
+      discord: config?.social?.discord,
       telegram: config?.social?.telegram,
     },
     resume: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,6 +105,11 @@ export interface Social {
   skype?: string;
 
   /**
+   * Discord link
+   */
+  discord?: string;
+
+  /**
    * Telegram username
    */
   telegram?: string;


### PR DESCRIPTION
This PR adds the option to include a Discord server link in the social links section.
Currently, the text that is displayed is the invite code as I didn't have a better idea of what to display for the link title. Feel free to suggest something else.

Partially resolves #380 