### PR TITLE
Add order the panels by edit panel name order

### DIFF
--- a/gitprofile.config.js
+++ b/gitprofile.config.js
@@ -10,7 +10,18 @@ const config = {
       projects: [], // These projects will not be displayed. example: ['my-project1', 'my-project2']
     },
   },
-  // Page panels. You can change the order of the panels.
+  // Page panels. You can change the order of the panels by edit panel name order.
+  // If you want theme-switch is under social-info
+  // example: left_panel: [
+  //   'personal-info',
+  //   'social-info',
+  //   'theme-switch',
+  //   'tech-stack',
+  //   'experience',
+  //   'education',
+  //   'certifications',
+  // ],
+  // Important: Don't remove any panel in left_panel or right_panel, even it is empty. (Just put it in the back)
   composition: {
     left_panel: [
       'theme-switch',

--- a/gitprofile.config.js
+++ b/gitprofile.config.js
@@ -10,6 +10,19 @@ const config = {
       projects: [], // These projects will not be displayed. example: ['my-project1', 'my-project2']
     },
   },
+  // Page panels. You can change the order of the panels.
+  composition: {
+    left_panel: [
+      'theme-switch',
+      'personal-info',
+      'social-info',
+      'tech-stack',
+      'experience',
+      'education',
+      'certifications',
+    ],
+    right_panel: ['github-projects', 'my-projects', 'recent-posts'],
+  },
   social: {
     linkedin: 'ariful-alam',
     twitter: 'arif_szn',

--- a/src/components/GitProfile.jsx
+++ b/src/components/GitProfile.jsx
@@ -110,6 +110,105 @@ const GitProfile = ({ config }) => {
       });
   }, [setLoading]);
 
+  let leftPanel = [];
+  let rightPanel = [];
+
+  for (let i = 0; i < sanitizedConfig.composition.left_panel.length; i++) {
+    switch (sanitizedConfig.composition.left_panel[i]) {
+      case 'theme-switch':
+        if (!sanitizedConfig.themeConfig.disableSwitch) {
+          leftPanel.push(
+            <ThemeChanger
+              theme={theme}
+              setTheme={setTheme}
+              loading={loading}
+              themeConfig={sanitizedConfig.themeConfig}
+            />
+          );
+        }
+        break;
+      case 'personal-info':
+        leftPanel.push(
+          <AvatarCard
+            profile={profile}
+            loading={loading}
+            avatarRing={!sanitizedConfig.themeConfig.hideAvatarRing}
+            resume={sanitizedConfig.resume}
+          />
+        );
+        break;
+      case 'social-info':
+        leftPanel.push(
+          <Details
+            profile={profile}
+            loading={loading}
+            github={sanitizedConfig.github}
+            social={sanitizedConfig.social}
+          />
+        );
+        break;
+      case 'tech-stack':
+        leftPanel.push(
+          <Skill loading={loading} skills={sanitizedConfig.skills} />
+        );
+        break;
+      case 'experience':
+        leftPanel.push(
+          <Experience
+            loading={loading}
+            experiences={sanitizedConfig.experiences}
+          />
+        );
+        break;
+      case 'education':
+        leftPanel.push(
+          <Education loading={loading} education={sanitizedConfig.education} />
+        );
+        break;
+      case 'certifications':
+        leftPanel.push(
+          <Certification
+            loading={loading}
+            certifications={sanitizedConfig.certifications}
+          />
+        );
+        break;
+    }
+  }
+
+  for (let i = 0; i < sanitizedConfig.composition.right_panel.length; i++) {
+    switch (sanitizedConfig.composition.right_panel[i]) {
+      case 'github-projects':
+        rightPanel.push(
+          <Project
+            repo={repo}
+            loading={loading}
+            github={sanitizedConfig.github}
+            googleAnalytics={sanitizedConfig.googleAnalytics}
+          />
+        );
+        break;
+      case 'my-projects':
+        rightPanel.push(
+          <ExternalProject
+            loading={loading}
+            externalProjects={sanitizedConfig.externalProjects}
+            googleAnalytics={sanitizedConfig.googleAnalytics}
+          />
+        );
+        break;
+      case 'recent-posts':
+        rightPanel.push(
+          <Blog
+            loading={loading}
+            googleAnalytics={sanitizedConfig.googleAnalytics}
+            blog={sanitizedConfig.blog}
+          />
+        );
+        break;
+    }
+  }
+
   const handleError = (error) => {
     console.error('Error:', error);
     try {
@@ -157,62 +256,20 @@ const GitProfile = ({ config }) => {
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 rounded-box">
                   <div className="col-span-1">
                     <div className="grid grid-cols-1 gap-6">
-                      {!sanitizedConfig.themeConfig.disableSwitch && (
-                        <ThemeChanger
-                          theme={theme}
-                          setTheme={setTheme}
-                          loading={loading}
-                          themeConfig={sanitizedConfig.themeConfig}
-                        />
-                      )}
-                      <AvatarCard
-                        profile={profile}
-                        loading={loading}
-                        avatarRing={!sanitizedConfig.themeConfig.hideAvatarRing}
-                        resume={sanitizedConfig.resume}
-                      />
-                      <Details
-                        profile={profile}
-                        loading={loading}
-                        github={sanitizedConfig.github}
-                        social={sanitizedConfig.social}
-                      />
-                      <Skill
-                        loading={loading}
-                        skills={sanitizedConfig.skills}
-                      />
-                      <Experience
-                        loading={loading}
-                        experiences={sanitizedConfig.experiences}
-                      />
-                      <Education
-                        loading={loading}
-                        education={sanitizedConfig.education}
-                      />
-                      <Certification
-                        loading={loading}
-                        certifications={sanitizedConfig.certifications}
-                      />
+                      {leftPanel.map((component, index) => (
+                        <Fragment key={`left-panel-${index}`}>
+                          {component}
+                        </Fragment>
+                      ))}
                     </div>
                   </div>
                   <div className="lg:col-span-2 col-span-1">
                     <div className="grid grid-cols-1 gap-6">
-                      <Project
-                        repo={repo}
-                        loading={loading}
-                        github={sanitizedConfig.github}
-                        googleAnalytics={sanitizedConfig.googleAnalytics}
-                      />
-                      <ExternalProject
-                        loading={loading}
-                        externalProjects={sanitizedConfig.externalProjects}
-                        googleAnalytics={sanitizedConfig.googleAnalytics}
-                      />
-                      <Blog
-                        loading={loading}
-                        googleAnalytics={sanitizedConfig.googleAnalytics}
-                        blog={sanitizedConfig.blog}
-                      />
+                      {rightPanel.map((component, index) => (
+                        <Fragment key={`right-panel-${index}`}>
+                          {component}
+                        </Fragment>
+                      ))}
                     </div>
                   </div>
                 </div>

--- a/src/helpers/utils.jsx
+++ b/src/helpers/utils.jsx
@@ -91,6 +91,50 @@ export const setupHotjar = (hotjarConfig) => {
 };
 
 export const sanitizeConfig = (config) => {
+  const defaultComposition = {
+    left_panel: [
+      'theme-switch',
+      'personal-info',
+      'social-info',
+      'tech-stack',
+      'experience',
+      'education',
+      'certifications',
+    ],
+    right_panel: ['github-projects', 'my-projects', 'recent-posts'],
+  };
+
+  let leftPanelState = true;
+  let rightPanelState = true;
+  if (
+    config?.composition?.left_panel &&
+    config?.composition?.right_panel &&
+    config?.composition?.left_panel.length == 7 &&
+    config?.composition?.right_panel.length == 3
+  ) {
+    for (let i = 0; i < config?.composition?.left_panel.length; i++) {
+      if (
+        !defaultComposition.left_panel.includes(
+          config?.composition?.left_panel[i]
+        )
+      ) {
+        leftPanelState = false;
+        break;
+      }
+    }
+
+    for (let i = 0; i < config?.composition?.right_panel.length; i++) {
+      if (
+        !defaultComposition.right_panel.includes(
+          config?.composition?.right_panel[i]
+        )
+      ) {
+        rightPanelState = false;
+        break;
+      }
+    }
+  }
+
   const customTheme = config?.themeConfig?.customTheme || {
     primary: '#fc055b',
     secondary: '#219aaf',
@@ -143,6 +187,14 @@ export const sanitizeConfig = (config) => {
         forks: config?.github?.exclude?.forks || false,
         projects: config?.github?.exclude?.projects || [],
       },
+    },
+    composition: {
+      left_panel: leftPanelState
+        ? config?.composition?.left_panel
+        : defaultComposition.left_panel,
+      right_panel: rightPanelState
+        ? config?.composition?.right_panel
+        : defaultComposition.right_panel,
     },
     social: {
       linkedin: config?.social?.linkedin,


### PR DESCRIPTION
```
  // Page panels. You can change the order of the panels by edit panel name order.
  // If you want theme-switch is under social-info
  // example: left_panel: [
  //   'personal-info',
  //   'social-info',
  //   'theme-switch',
  //   'tech-stack',
  //   'experience',
  //   'education',
  //   'certifications',
  // ],
  // Important: Don't remove any panel in left_panel or right_panel, even it is empty. (Just put it in the back)
  composition: {
    left_panel: [
      'theme-switch',
      'personal-info',
      'social-info',
      'tech-stack',
      'experience',
      'education',
      'certifications',
    ],
    right_panel: ['github-projects', 'my-projects', 'recent-posts'],
  },
```

User can use this config to set their own component order for Profile.