### PR TITLE
Theme Changer Accesibility Tweaks

### DIFF
--- a/src/components/theme-changer/index.tsx
+++ b/src/components/theme-changer/index.tsx
@@ -70,11 +70,12 @@ const ThemeChanger = ({
               className: 'mr-6',
             })
           ) : (
-            <div title="Change Theme" className="dropdown dropdown-end">
-              <div
-                tabIndex={0}
-                className="btn btn-ghost m-1 normal-case opacity-50 text-base-content"
-              >
+            <div
+              title="Change Theme"
+              className="dropdown dropdown-end"
+              tabIndex={0}
+            >
+              <div className="btn btn-ghost m-1 normal-case opacity-50 text-base-content">
                 <AiOutlineControl className="inline-block w-5 h-5 stroke-current md:mr-2" />
                 <span className="hidden md:inline">Change Theme</span>
                 <svg
@@ -85,10 +86,7 @@ const ThemeChanger = ({
                   <path d="M1395 736q0 13-10 23l-466 466q-10 10-23 10t-23-10l-466-466q-10-10-10-23t10-23l50-50q10-10 23-10t23 10l393 393 393-393q10-10 23-10t23 10l50 50q10 10 10 23z" />
                 </svg>
               </div>
-              <div
-                tabIndex={0}
-                className="mt-16 overflow-y-auto shadow-2xl top-px dropdown-content max-h-96 w-52 rounded-lg bg-base-200 text-base-content z-10"
-              >
+              <div className="mt-16 overflow-y-auto shadow-2xl top-px dropdown-content max-h-96 w-52 rounded-lg bg-base-200 text-base-content z-10">
                 <ul className="p-4 menu compact">
                   {[
                     themeConfig.defaultTheme,
@@ -100,6 +98,7 @@ const ThemeChanger = ({
                       {}
                       <a
                         onClick={(e) => changeTheme(e, item)}
+                        tabIndex={0}
                         className={`${theme === item ? 'active' : ''}`}
                       >
                         <span className="opacity-60 capitalize">

--- a/src/components/theme-changer/index.tsx
+++ b/src/components/theme-changer/index.tsx
@@ -96,6 +96,11 @@ const ThemeChanger = ({
                           e.preventDefault();
                           changeTheme(item);
                         }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            changeTheme(item);
+                          }
+                        }}
                         className={`${theme === item ? 'active' : ''}`}
                       >
                         <span className="opacity-60 capitalize">

--- a/src/components/theme-changer/index.tsx
+++ b/src/components/theme-changer/index.tsx
@@ -2,7 +2,6 @@ import { AiOutlineControl } from 'react-icons/ai';
 import { SanitizedThemeConfig } from '../../interfaces/sanitized-config';
 import { LOCAL_STORAGE_KEY_NAME } from '../../constants';
 import { skeleton } from '../../utils';
-import { MouseEvent } from 'react';
 
 /**
  * Renders a theme changer component.
@@ -25,12 +24,7 @@ const ThemeChanger = ({
   loading: boolean;
   themeConfig: SanitizedThemeConfig;
 }) => {
-  const changeTheme = (
-    e: MouseEvent<HTMLAnchorElement>,
-    selectedTheme: string,
-  ) => {
-    e.preventDefault();
-
+  const changeTheme = (selectedTheme: string) => {
     document.querySelector('html')?.setAttribute('data-theme', selectedTheme);
 
     typeof window !== 'undefined' &&
@@ -97,8 +91,11 @@ const ThemeChanger = ({
                     <li key={index}>
                       {}
                       <a
-                        onClick={(e) => changeTheme(e, item)}
                         tabIndex={0}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          changeTheme(item);
+                        }}
                         className={`${theme === item ? 'active' : ''}`}
                       >
                         <span className="opacity-60 capitalize">


### PR DESCRIPTION
- theme changer: improve tabbability
indexed each theme's anchor tag, for easier keyboard navigation
- theme changer: moved prevent default call
- theme changer: add handler for Enter keypress
allows changing themes using keyboard only,  
would probably improve accisibility
