### PR TITLE
Added support for Matrix on the social list

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -118,6 +118,11 @@ interface Social {
   twitter?: string;
 
   /**
+   * Matrix username
+   */
+  matrix?: string;
+
+  /**
    * Mastodon
    */
   mastodon?: string;

--- a/src/components/details-card/index.tsx
+++ b/src/components/details-card/index.tsx
@@ -20,6 +20,7 @@ import {
   FaYoutube,
 } from 'react-icons/fa';
 import { FaSquareThreads } from 'react-icons/fa6';
+import { PiMatrixLogoFill } from 'react-icons/pi';
 import { MdLocationOn } from 'react-icons/md';
 import { RiMailFill, RiPhoneFill } from 'react-icons/ri';
 import { SiResearchgate, SiTwitter, SiUdemy } from 'react-icons/si';
@@ -224,6 +225,14 @@ const DetailsCard = ({ profile, loading, social, github }: Props) => {
                   title="Mastodon:"
                   value={getFormattedMastodonValue(social.mastodon, false)}
                   link={getFormattedMastodonValue(social.mastodon, true)}
+                />
+              )}
+              {social?.matrix && (
+                <ListItem
+                icon={<PiMatrixLogoFill />}
+                title="Matrix"
+                value={social.matrix}
+                link={`https://matrix.to/#/${social.matrix}`}
                 />
               )}
               {social?.linkedin && (

--- a/src/interfaces/sanitized-config.tsx
+++ b/src/interfaces/sanitized-config.tsx
@@ -63,6 +63,7 @@ export interface SanitizedSocial {
   telegram?: string;
   phone?: string;
   email?: string;
+  matrix?: string;
 }
 
 export interface SanitizedResume {

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -81,6 +81,7 @@ export const getSanitizedConfig = (
         skype: config?.social?.skype,
         telegram: config?.social?.telegram,
         researchGate: config?.social?.researchGate,
+        matrix: config?.social?.matrix,
       },
       resume: {
         fileUrl: config?.resume?.fileUrl || '',


### PR DESCRIPTION
Added support for the [Matrix](https://matrix.org/) social network in the social list, the added link is a [matrix.to](https://matrix.to/) link, since there is no user specific link.

showcase:
![matrix_showcase](https://github.com/user-attachments/assets/340ddcf0-3a3f-4107-803b-aae82e3a7dd8)