### PR TITLE
Remove redundant cache restore steps from workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,13 +31,6 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,13 +17,6 @@ jobs:
           node-version: 20.x
           cache: 'npm'
 
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary
- remove manual actions/cache restore steps from deploy and test-deploy workflows since setup-node already handles npm caching

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900954987948326a6cb78151271a0f3