### PR TITLE
Simplify localStorage null check for better readability

### DIFF
--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -141,7 +141,7 @@ export const getInitialTheme = (themeConfig: SanitizedThemeConfig): string => {
 
   if (
     typeof window !== 'undefined' &&
-    !(localStorage.getItem(LOCAL_STORAGE_KEY_NAME) === null)
+    localStorage.getItem(LOCAL_STORAGE_KEY_NAME) !== null
   ) {
     const savedTheme = localStorage.getItem(LOCAL_STORAGE_KEY_NAME);
 


### PR DESCRIPTION
### Before:
`!(localStorage.getItem(LOCAL_STORAGE_KEY_NAME) === null)`
### After: 
`localStorage.getItem(LOCAL_STORAGE_KEY_NAME) !== null`

Changes:
- Replaced negated equality check with direct positive comparison
- Improved code readability by eliminating double negation
- Made the intent more explicit and easier to understand

This follows clean code best practices by preferring positive conditionals over negated ones