### PR TITLE
Remove email from gitprofile configuration

### DIFF
--- a/gitprofile.config.ts
+++ b/gitprofile.config.ts
@@ -72,7 +72,7 @@ const CONFIG = {
     telegram: '',
     website: 'https://www.arifszn.com',
     phone: '',
-    email: 'arifulalamszn@gmail.com',
+    email: '',
   },
   resume: {
     fileUrl:


### PR DESCRIPTION
Removed email address from configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the configured email contact from the portfolio configuration.
> 
> - Sets `social.email` to an empty string in `gitprofile.config.ts` to hide/remove the email from the profile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c83fe74ff8a94d9c014533a7077372314aafcd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->